### PR TITLE
Fix Long import

### DIFF
--- a/src/CompoundFile.ts
+++ b/src/CompoundFile.ts
@@ -14,7 +14,7 @@ import {FixedSizeChunkedDataview} from "./dataview/FixedSizeChunkedDataview";
 import {ENDOFCHAIN_MARK, ENDOFCHAIN_MARK_INT} from "./utils";
 import { DirectoryEntry } from "./directory/DirectoryEntry";
 import * as Long from "long";
-import "Long";
+import "./Long";
 import {RootStorageDirectoryEntry} from "./directory/RootStorageDirectoryEntry";
 import {StorageDirectoryEntry} from "./directory/StorageDirectoryEntry";
 import {StreamDirectoryEntry} from "./directory/StreamDirectoryEntry";


### PR DESCRIPTION
This PR fixes what I think is an incorrect `import` statement. On file systems that are case insensitive like OSX, `import Long` actually imports the `long` module which is a dependency of this library, whereas on case sensitive file systems like Linux `import Long` throws an error - I therefore assume that this line in supposed to import the local `Long.ts` file.